### PR TITLE
Exclude com.google.zxing to avoid conflicts

### DIFF
--- a/src/android/barcodescanner.gradle
+++ b/src/android/barcodescanner.gradle
@@ -15,3 +15,7 @@ android {
         exclude 'META-INF/LICENSE'
     }
 }
+
+configurations {
+    compile.exclude group: 'com.google.zxing'
+}


### PR DESCRIPTION
Exclude com.google.zxing group to [avoid conflicts with other Cordova plugins](https://github.com/phonegap/phonegap-plugin-barcodescanner/issues/535#issuecomment-518626750). Should fix #535 and #614

